### PR TITLE
Add search osc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Mandatory `type` argument to specify what kind of evaluation is requested:
 `row` and `column` parameters can be specified to move the cursor on that position before the evaluation.
 
 #### Search
-With the `search` parameter, you are able to to move the cursort to the first occurance that matches the search term.
+With the `search` parameter, you are able to to move the cursor to the first occurrence that matches the search term.
 
 ### Sound Browser
 To make the sound browser at the first tidal evaluation, add your paths to the `Sound Browser Folders` in the plugin configuration, separed by commas.\

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Mandatory `type` argument to specify what kind of evaluation is requested:
 ##### Row / Column
 `row` and `column` parameters can be specified to move the cursor on that position before the evaluation.
 
+#### Search
+With the `search` parameter, you are able to to move the cursort to the first occurance that matches the search term.
+
 ### Sound Browser
 To make the sound browser at the first tidal evaluation, add your paths to the `Sound Browser Folders` in the plugin configuration, separed by commas.\
 Restart atom to apply changes.

--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -30,6 +30,10 @@ export default class OscLoader extends EventEmitter {
                     this.editors.goTo(resultDict['row'] - 1, resultDict['column'])
                 }
 
+                if (resultDict['tab'] !== undefined) {
+                    atom.workspace.getPanes()[0].setActiveItem(atom.workspace.getTextEditors()[resultDict['tab']])
+                }
+
                 if (resultDict['search']) {
                     const lineNumber = this.editors.currentEditor().getText().split("\n").findIndex(line => line.includes(resultDict['search']));
                     if (lineNumber > -1)  {

--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -30,6 +30,14 @@ export default class OscLoader extends EventEmitter {
                     this.editors.goTo(resultDict['row'] - 1, resultDict['column'])
                 }
 
+                if (resultDict['search']) {
+                    const lineNumber = this.editors.currentEditor().getText().split("\n").findIndex(line => line.includes(resultDict['search']));
+                    if (lineNumber > -1)  {
+                      this.editors.goTo(lineNumber, 0)
+                      this.editors.currentEditor().setScrollTopRow(lineNumber)
+                    }
+                }
+
                 this.tidalRepl.eval(resultDict['type'], false);
             }
         });


### PR DESCRIPTION
I added a new osc option to the plugin. 

With the `search` parameter, you are able to to move the cursort to the first occurance that matches the search term.

Fun fact: I forked the `tidalcycles/pulsar-tidalcycles` repository and Github changed it to `thgrund/atom-tidalcycles`. xD