### PR TITLE
feat: Search the Sound Browser

### DIFF
--- a/lib/sound-browser.js
+++ b/lib/sound-browser.js
@@ -15,6 +15,8 @@ export default class SoundBrowser {
     this.browser.classList.add('atom-sound-browser')
     this.browser.style.overflowY = 'scroll'
 
+    this.initSearch()
+
     let trees = soundFolders
       .map(folder => {
         let tree = dirTree(folder, {
@@ -50,7 +52,7 @@ export default class SoundBrowser {
 
     if (tree.type === 'directory') {
       element.textContent = tree.name
-      element.classList.add('icon', 'icon-open')
+      element.classList.add('icon', 'icon-open', 'tidal-dir')
 
       let directoryElement = document.createElement('ul')
       element.onclick = _ => {
@@ -67,7 +69,7 @@ export default class SoundBrowser {
       let dirName = path.basename(path.dirname(tree.path))
       let filename = path.basename(tree.path, path.extname(tree.path))
       element.textContent = `${dirName}:${number} / ${filename}`
-      element.classList.add('icon', 'icon-speaker')
+      element.classList.add('icon', 'icon-speaker', 'tidal-sample')
 
       let audioIcon = document.createElement('span');
       element.appendChild(audioIcon);
@@ -116,6 +118,48 @@ export default class SoundBrowser {
     played ?
         element.classList.add('icon-speaker') :
         element.classList.remove('icon-speaker');
+  }
+
+  initSearch() {
+
+    this.searchBox = document.createElement("input")
+    this.searchBox.type = "text"
+    this.searchBox.id = "search"
+    this.searchBox.classList.add("searchBox")
+    this.searchBox.style.backgroundColor= "#333"
+
+    let searchText = ""
+
+    const filterElement = function(element, searchText) {
+      const dir = element.parentNode.previousSibling
+      const rootDir = element.parentNode.parentNode.previousSibling
+      searchText = searchText.toLowerCase().trim()
+      let weight = "normal"
+
+      if (searchText.length != 0) {
+        var selected = element.innerText.toLowerCase().includes(searchText)
+        weight = selected ? "bold" : "lighter"
+
+        if (selected) {
+          console.log(`Matched ${element.innerText}! (${dir.innerText})`)
+        }
+      }
+      element.style.fontWeight = weight
+      dir.style.fontWeight = weight
+      rootDir.style.fontWeight = weight
+    }
+
+    const onchange = function(e) {
+      this.searchText = e.target.value
+      let samples = document.getElementsByClassName("tidal-sample")
+      let dirs = document.getElementsByClassName("tidal-dir")
+      Array.from(samples).forEach((sample) => filterElement(sample, this.searchText))
+    }
+
+    this.searchBox.addEventListener('input', onchange);
+    this.searchBox.addEventListener('propertychange', onchange);
+
+    this.browser.appendChild(this.searchBox)
   }
 
   toggleDisplay(parent, element) {

--- a/lib/sound-browser.js
+++ b/lib/sound-browser.js
@@ -15,7 +15,9 @@ export default class SoundBrowser {
     this.browser.classList.add('atom-sound-browser')
     this.browser.style.overflowY = 'scroll'
 
+    console.time("Init Search");
     this.initSearch()
+    console.timeEnd("Init Search");
 
     let trees = soundFolders
       .map(folder => {
@@ -34,12 +36,14 @@ export default class SoundBrowser {
     if (trees.length > 0) {
       trees.forEach(tree => this.render(this.browser, tree, 0))
 
+      console.time("OpenWS");
       atom.workspace.open({
         element: this.browser,
         getTitle: () => 'Sound Browser',
         getURI: () => 'atom://tidalcycles/sound-browser',
         getDefaultLocation: () => 'left'
       }, { activatePane: false });
+      console.timeEnd("OpenWS");
     }
   }
 
@@ -125,10 +129,21 @@ export default class SoundBrowser {
     this.searchBox = document.createElement("input")
     this.searchBox.type = "text"
     this.searchBox.id = "search"
+    this.searchBox.placeholder = "Search your Samples"
     this.searchBox.classList.add("searchBox")
     this.searchBox.style.backgroundColor= "#333"
 
-    let searchText = ""
+    this.clearButton = document.createElement("button")
+    this.clearButton.type = "button"
+    this.clearButton.style.cursor = "pointer"
+    this.clearButton.style.backgroundColor = "#046DAA;"
+    this.clearButton.style.padding = "5px"
+    this.clearButton.textContent = "[X]"
+
+    // this.clearButton.onClick = (this.searchBox) => {
+      // searchBox.textContent = ""
+      // console.log("Reset query.")
+    // }
 
     const filterElement = function(element, searchText, folders) {
       const dir = element.parentNode.previousSibling
@@ -138,13 +153,13 @@ export default class SoundBrowser {
       let weight = "normal"
 
       if (searchText.length != 0) {
-        var selected = element.innerText.toLowerCase().includes(searchText)
-        display = selected ? "block" : "none"
-        weight = selected ? "bold": "normal"
+        var isMatch = element.innerText.toLowerCase().includes(searchText)
+        display = isMatch ? "block" : "none"
+        weight = isMatch ? "bold": "normal"
 
-        if (selected) {
-          console.log(`Matched ${element.innerText}! (${dir.innerText}) -> ${display}/${weight}`)
-        }
+        // if (selected) {
+          // console.log(`Matched ${element.innerText}! (${dir.innerText}) -> ${display}/${weight}`)
+        // }
       }
       element.style.display = display
       element.style.fontWeight = weight
@@ -154,9 +169,17 @@ export default class SoundBrowser {
     }
 
     const filterEmptyDir = (dir) => {
-      console.log(dir)
+      if (dir.children.length > 0) {
+        console.log("Dir ", dir.innerText, ":", dir.classList, " has ", dir.children.length, " children:");
+        for (var i=0;i<dir.children.length;i++) {
+          let child = dir.children[i];
+          console.log(child.classList);
+        }
+      }
+
     }
 
+    // TODO: Debounce input might improve UX?
     function debounce(func, timeout = 300){
       let timer;
       return (...args) => {
@@ -167,20 +190,34 @@ export default class SoundBrowser {
         }, timeout);
       };
     }
-
     // const processChange = debounce(() => saveInput());
 
     const onchange = function(e) {
-      searchText = e.target.value
-      console.log(searchText)
+      let searchText = e.target.value
       let samples = document.getElementsByClassName("tidal-sample")
       let dirs = document.getElementsByClassName("tidal-dir")
+      console.log("Q: ", searchText, "L(D)=", dirs.length, "L(S)=", samples.length);
+      if (searchText.length < 2) {
+        console.error("DEBOUNCE: Ignoring tiny query ", searchText, ".")
+        return
+      }
+      console.time('samples');
       Array.from(samples).forEach(
         (sample) => filterElement(sample, searchText, this.soundFolders)
       )
+      console.timeEnd('samples');
+      console.time('dirs');
+      var printed=0;
       Array.from(dirs).forEach(
-        (dir) => filterEmptyDir(dir)
+        (dir) => {
+          if (printed++ < 3) {
+            console.log(`Processing ${dir}...`);
+            console.log(dir);
+          }
+          filterEmptyDir(dir)
+        }
       )
+      console.timeEnd('dirs');
     }
 
     this.searchBox.addEventListener('input', onchange);

--- a/lib/sound-browser.js
+++ b/lib/sound-browser.js
@@ -130,30 +130,57 @@ export default class SoundBrowser {
 
     let searchText = ""
 
-    const filterElement = function(element, searchText) {
+    const filterElement = function(element, searchText, folders) {
       const dir = element.parentNode.previousSibling
       const rootDir = element.parentNode.parentNode.previousSibling
       searchText = searchText.toLowerCase().trim()
+      let display = "block"
       let weight = "normal"
 
       if (searchText.length != 0) {
         var selected = element.innerText.toLowerCase().includes(searchText)
-        weight = selected ? "bold" : "lighter"
+        display = selected ? "block" : "none"
+        weight = selected ? "bold": "normal"
 
         if (selected) {
-          console.log(`Matched ${element.innerText}! (${dir.innerText})`)
+          console.log(`Matched ${element.innerText}! (${dir.innerText}) -> ${display}/${weight}`)
         }
       }
+      element.style.display = display
       element.style.fontWeight = weight
+      dir.style.display = display
       dir.style.fontWeight = weight
       rootDir.style.fontWeight = weight
     }
 
+    const filterEmptyDir = (dir) => {
+      console.log(dir)
+    }
+
+    function debounce(func, timeout = 300){
+      let timer;
+      return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          console.log("TIMEOUT");
+          func.apply(this, args);
+        }, timeout);
+      };
+    }
+
+    // const processChange = debounce(() => saveInput());
+
     const onchange = function(e) {
-      this.searchText = e.target.value
+      searchText = e.target.value
+      console.log(searchText)
       let samples = document.getElementsByClassName("tidal-sample")
       let dirs = document.getElementsByClassName("tidal-dir")
-      Array.from(samples).forEach((sample) => filterElement(sample, this.searchText))
+      Array.from(samples).forEach(
+        (sample) => filterElement(sample, searchText, this.soundFolders)
+      )
+      Array.from(dirs).forEach(
+        (dir) => filterEmptyDir(dir)
+      )
     }
 
     this.searchBox.addEventListener('input', onchange);


### PR DESCRIPTION
I've got 37k samples accessible in my Tidalcycles setup, so the sound browser is a **godsend**

But I struggle to scan it even with the browser's tree view

So I built a search feature:
<img src="https://github.com/user-attachments/assets/7c2f4082-e33b-46b8-b134-a55c7105f6fd" width=50% height=50%>

It filters to only dirs that have matches in their name or their samples' names:
<img src="https://github.com/user-attachments/assets/64e4ef22-8e6e-4f82-a06d-41616cc86e08" width=50% height=50%>

Filters within folders too:
<img src="https://github.com/user-attachments/assets/1ae03c67-99dd-4a77-857e-08e467466607" width=50% height=50%>

And when you play them once they get back to normal font weight, here you can see which `tom` in the `rampleP3` folder I listened to since the last "tom" search:

<img src="https://github.com/user-attachments/assets/39de689e-5544-46fc-8557-e9873ef866ae" width=50% height=50%>


I don't think we should merge it now though! :construction: :construction_worker: 

- The code is quite slow on my 30k+ samples set, surely there are ways to make it more performant? I only started timing parts to see what's the bottleneck
- Maybe some edge cases are not properly handled yet, I need to test it more
- Overall I'm not confident in my JS, would love code review with honest comments
 

Let me know what you think :heart_hands: 
  