### PR TITLE
Fix issue #206: Changing tab before changing line evaluation via OSC

### DIFF
--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -26,12 +26,12 @@ export default class OscLoader extends EventEmitter {
             if (resultMap.address === this.address) {
                 const resultDict = this.asDictionary(resultMap.args)
 
-                if (resultDict['row'] && resultDict['column']) {
-                    this.editors.goTo(resultDict['row'] - 1, resultDict['column'])
-                }
-
                 if (resultDict['tab'] !== undefined) {
                     atom.workspace.getPanes()[0].setActiveItem(atom.workspace.getTextEditors()[resultDict['tab']])
+                }
+
+                if (resultDict['row'] && resultDict['column']) {
+                    this.editors.goTo(resultDict['row'] - 1, resultDict['column'])
                 }
 
                 this.tidalRepl.eval(resultDict['type'], false);


### PR DESCRIPTION
The change of tab has to come before the change of line evaluation in order that the line of the specified tab is correctly evaluated. Otherwise, the line of the previous tab is evaluated instead.

Closes #206 