### PR TITLE
[Event Highlighting]: White label minus, dot and colon chars in mini notation

### DIFF
--- a/lib/event-highlighter.js
+++ b/lib/event-highlighter.js
@@ -199,9 +199,8 @@ export default class EventHighlighter {
   #removeHighlight({ colStart, eventId }) {
 
     const highlightEvents = this.highlights.get(eventId);
-    // console.log("removeHighlight", highlightEvents, eventId, colStart);
 
-    if (!highlightEvents.size) return;
+    if (!highlightEvents || !highlightEvents.size) return;
 
      highlightEvents.forEach(textEditorIdEvent => {
       const marker = textEditorIdEvent.get(colStart);

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -15,7 +15,7 @@ export default class LineProcessor {
         const lowerCaseMin = 97;
         const lowerCaseMax = 122;
         // .
-         const dot = 46;
+        const dot = 46;
         // -
         const minus = 45;
 

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -18,13 +18,16 @@ export default class LineProcessor {
         const dot = 46;
         // -
         const minus = 45;
+        // :
+        const colon = 58;
 
         return (
             (code >= digitMin && code <= digitMax) ||
             (code >= upperCaseMin && code <= upperCaseMax) ||
             (code >= lowerCaseMin && code <= lowerCaseMax) ||
             (code == dot) ||
-            (code == minus)
+            (code == minus) ||
+            (code == colon)
         );
     }
 
@@ -32,20 +35,20 @@ export default class LineProcessor {
         const code = character.charCodeAt(0);
         // "
         const quotationMark = 34;
-    
+
         return code === quotationMark;
     }
-    
+
     static findTidalWordRanges(line, callback) {
         let insideQuotes = false;
     	let start = null;
     	let end = null;
-   
+
     	Array.from(line).forEach((char, index) => {
             if (LineProcessor.isQuotationMark(char)) {
                 insideQuotes = !insideQuotes;
             }
-           
+
             if (insideQuotes && LineProcessor.isValidTidalWordChar(char)) {
                if (!start) {
             	start = index;
@@ -62,11 +65,11 @@ export default class LineProcessor {
             }
         })
     }
-    
+
     static controlPatternsRegex() {
         return new RegExp(/"([^"]*)"/g);
     }
-    
+
     static exceptedFunctionPatterns() {
         return new RegExp(/numerals\s*=.*$|p\s.*$/);
     }

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -2,72 +2,72 @@
 
 export default class LineProcessor {
 
-	// Valid TidalCycles word chars
-	static isValidTidalWordChar(character) {
-     const code = character.charCodeAt(0);
-     // 0-9
-     const digitMin = 48;
-     const digitMax = 57;
-	   // A-Z
-	   const upperCaseMin = 65;
-	   const upperCaseMax = 90;
-	   // a-z
-	   const lowerCaseMin = 97;
-	   const lowerCaseMax = 122;
-		 // .
-		 const dot = 46;
-		 // -
-		 const minus = 45;
+    // Valid TidalCycles word chars
+    static isValidTidalWordChar(character) {
+        const code = character.charCodeAt(0);
+        // 0-9
+        const digitMin = 48;
+        const digitMax = 57;
+        // A-Z
+        const upperCaseMin = 65;
+        const upperCaseMax = 90;
+        // a-z
+        const lowerCaseMin = 97;
+        const lowerCaseMax = 122;
+        // .
+         const dot = 46;
+        // -
+        const minus = 45;
 
-     return (
-       (code >= digitMin && code <= digitMax) ||
-       (code >= upperCaseMin && code <= upperCaseMax) ||
-			 (code >= lowerCaseMin && code <= lowerCaseMax) ||
-			 (code == dot) ||
-			 (code == minus)
-     );
- 	}
+        return (
+            (code >= digitMin && code <= digitMax) ||
+            (code >= upperCaseMin && code <= upperCaseMax) ||
+            (code >= lowerCaseMin && code <= lowerCaseMax) ||
+            (code == dot) ||
+            (code == minus)
+        );
+    }
 
-	static isQuotationMark(character) {
-           const code = character.charCodeAt(0);
-	   // "
-	   const quotationMark = 34;
-
-           return code === quotationMark;
- 	}
-
-	static findTidalWordRanges(line, callback) {
-		let insideQuotes = false;
-		let start = null;
-		let end = null;
-
-		Array.from(line).forEach((char, index) => {
-			if (LineProcessor.isQuotationMark(char)) {
-				insideQuotes = !insideQuotes;
-			}
-
-			if (insideQuotes && LineProcessor.isValidTidalWordChar(char)) {
-			   if (!start) {
-				start = index;
-				end = index;
-			   } else {
-				end++;
-			   }
-			} else {
-			  if (start && end) {
-				callback({start, end});
-				start = null;
-				end = null;
-			  }
-			}
-		})
-	}
-
-	static controlPatternsRegex() {
-		return new RegExp(/"([^"]*)"/g);
-	}
-
-	static exceptedFunctionPatterns() {
-		return new RegExp(/numerals\s*=.*$|p\s.*$/);
-	}
+    static isQuotationMark(character) {
+        const code = character.charCodeAt(0);
+        // "
+        const quotationMark = 34;
+    
+        return code === quotationMark;
+    }
+    
+    static findTidalWordRanges(line, callback) {
+        let insideQuotes = false;
+    	let start = null;
+    	let end = null;
+   
+    	Array.from(line).forEach((char, index) => {
+            if (LineProcessor.isQuotationMark(char)) {
+                insideQuotes = !insideQuotes;
+            }
+           
+            if (insideQuotes && LineProcessor.isValidTidalWordChar(char)) {
+               if (!start) {
+            	start = index;
+            	end = index;
+               } else {
+            	end++;
+               }
+            } else {
+                if (start && end) {
+                    callback({start, end});
+                  	start = null;
+                  	end = null;
+                }
+            }
+        })
+    }
+    
+    static controlPatternsRegex() {
+        return new RegExp(/"([^"]*)"/g);
+    }
+    
+    static exceptedFunctionPatterns() {
+        return new RegExp(/numerals\s*=.*$|p\s.*$/);
+    }
 }

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -1,76 +1,69 @@
 'use babel'
 
 export default class LineProcessor {
+  // private static constants
+  static #DIGIT_MIN = 48;
+  static #DIGIT_MAX = 57;
+  static #UPPERCASE_MIN = 65;
+  static #UPPERCASE_MAX = 90;
+  static #LOWERCASE_MIN = 97;
+  static #LOWERCASE_MAX = 122;
+  static #DOT = 46;
+  static #MINUS = 45;
+  static #COLON = 58;
+  static #QUOTATION_MARK = 34;
 
-    // Valid TidalCycles word chars
-    static isValidTidalWordChar(character) {
-        const code = character.charCodeAt(0);
-        // 0-9
-        const digitMin = 48;
-        const digitMax = 57;
-        // A-Z
-        const upperCaseMin = 65;
-        const upperCaseMax = 90;
-        // a-z
-        const lowerCaseMin = 97;
-        const lowerCaseMax = 122;
-        // .
-        const dot = 46;
-        // -
-        const minus = 45;
-        // :
-        const colon = 58;
+  // Valid TidalCycles word chars
+  static isValidTidalWordChar(character) {
+    const code = character.charCodeAt(0);
 
-        return (
-            (code >= digitMin && code <= digitMax) ||
-            (code >= upperCaseMin && code <= upperCaseMax) ||
-            (code >= lowerCaseMin && code <= lowerCaseMax) ||
-            (code == dot) ||
-            (code == minus) ||
-            (code == colon)
-        );
-    }
+    return (
+      (code >= LineProcessor.#DIGIT_MIN && code <= LineProcessor.#DIGIT_MAX) ||
+      (code >= LineProcessor.#UPPERCASE_MIN && code <= LineProcessor.#UPPERCASE_MAX) ||
+      (code >= LineProcessor.#LOWERCASE_MIN && code <= LineProcessor.#LOWERCASE_MAX) ||
+      (code === LineProcessor.#DOT) ||
+      (code === LineProcessor.#MINUS) ||
+      (code === LineProcessor.#COLON)
+    );
+  }
 
-    static isQuotationMark(character) {
-        const code = character.charCodeAt(0);
-        // "
-        const quotationMark = 34;
+  static isQuotationMark(character) {
+    return character.charCodeAt(0) === LineProcessor.#QUOTATION_MARK;
+  }
 
-        return code === quotationMark;
-    }
+  static findTidalWordRanges(line, callback) {
+    let insideQuotes = false;
+    let start = null;
+    let end = null;
 
-    static findTidalWordRanges(line, callback) {
-        let insideQuotes = false;
-    	let start = null;
-    	let end = null;
+    Array.from(line).forEach((char, index) => {
+      if (LineProcessor.isQuotationMark(char)) {
+        insideQuotes = !insideQuotes;
+      }
 
-    	Array.from(line).forEach((char, index) => {
-            if (LineProcessor.isQuotationMark(char)) {
-                insideQuotes = !insideQuotes;
-            }
+      if (insideQuotes && LineProcessor.isValidTidalWordChar(char)) {
+        if (start === null) {
+          start = index;
+          end = index;
+        } else {
+          end++;
+        }
+      } else {
+        if (start !== null && end !== null) {
+          callback({ start, end });
+          start = null;
+          end = null;
+        }
+      }
+    });
+  }
 
-            if (insideQuotes && LineProcessor.isValidTidalWordChar(char)) {
-               if (!start) {
-            	start = index;
-            	end = index;
-               } else {
-            	end++;
-               }
-            } else {
-                if (start && end) {
-                    callback({start, end});
-                  	start = null;
-                  	end = null;
-                }
-            }
-        })
-    }
+  static controlPatternsRegex() {
+    return /"([^"]*)"/g;
+  }
 
-    static controlPatternsRegex() {
-        return new RegExp(/"([^"]*)"/g);
-    }
-
-    static exceptedFunctionPatterns() {
-        return new RegExp(/numerals\s*=.*$|p\s.*$/);
-    }
+  static exceptedFunctionPatterns() {
+    return /numerals\s*=.*$|p\s.*$/;
+  }
 }
+

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -4,24 +4,30 @@ export default class LineProcessor {
 
 	// Valid TidalCycles word chars
 	static isValidTidalWordChar(character) {
-           const code = character.charCodeAt(0);
-           // 0-9
-           const digitMin = 48;
-           const digitMax = 57;
+     const code = character.charCodeAt(0);
+     // 0-9
+     const digitMin = 48;
+     const digitMax = 57;
 	   // A-Z
 	   const upperCaseMin = 65;
 	   const upperCaseMax = 90;
 	   // a-z
 	   const lowerCaseMin = 97;
 	   const lowerCaseMax = 122;
+		 // .
+		 const dot = 46;
+		 // -
+		 const minus = 45;
 
-           return (
-             (code >= digitMin && code <= digitMax) ||
-             (code >= upperCaseMin && code <= upperCaseMax) ||
-             (code >= lowerCaseMin && code <= lowerCaseMax)
-           );
+     return (
+       (code >= digitMin && code <= digitMax) ||
+       (code >= upperCaseMin && code <= upperCaseMax) ||
+			 (code >= lowerCaseMin && code <= lowerCaseMax) ||
+			 (code == dot) ||
+			 (code == minus)
+     );
  	}
-	
+
 	static isQuotationMark(character) {
            const code = character.charCodeAt(0);
 	   // "
@@ -38,7 +44,7 @@ export default class LineProcessor {
 		Array.from(line).forEach((char, index) => {
 			if (LineProcessor.isQuotationMark(char)) {
 				insideQuotes = !insideQuotes;
-			} 
+			}
 
 			if (insideQuotes && LineProcessor.isValidTidalWordChar(char)) {
 			   if (!start) {
@@ -54,14 +60,14 @@ export default class LineProcessor {
 				end = null;
 			  }
 			}
-		})		
+		})
 	}
 
 	static controlPatternsRegex() {
-		return new RegExp(/"([^"]*)"/g);	
+		return new RegExp(/"([^"]*)"/g);
 	}
 
 	static exceptedFunctionPatterns() {
-		return new RegExp(/numerals\s*=.*$|p\s.*$/);	
+		return new RegExp(/numerals\s*=.*$|p\s.*$/);
 	}
 }

--- a/spec/line-processor-spec.js
+++ b/spec/line-processor-spec.js
@@ -3,46 +3,46 @@ const LineProcessor = require("../lib/line-processor");
 describe('Line Processor', () => {
 
     describe('isValidTidalWordChar', () => {
-	it('should truthify a valid digit', () => {
-		expect(LineProcessor.isValidTidalWordChar('5')).toBe(true);
-	})
-	it('should truthify a valid upper case char', () => {
-		expect(LineProcessor.isValidTidalWordChar('M')).toBe(true);
-	})
+	    it('should truthify a valid digit', () => {
+	    	expect(LineProcessor.isValidTidalWordChar('5')).toBe(true);
+	    })
+	    it('should truthify a valid upper case char', () => {
+	    	expect(LineProcessor.isValidTidalWordChar('M')).toBe(true);
+	    })
 
-	it('should truthify a valid lower case char', () => {
-		expect(LineProcessor.isValidTidalWordChar('t')).toBe(true);
-	})
+	    it('should truthify a valid lower case char', () => {
+	    	expect(LineProcessor.isValidTidalWordChar('t')).toBe(true);
+	    })
 
-	it('should falsify an invalid char', () => {
-		expect(LineProcessor.isValidTidalWordChar('*')).toBe(false);
-	})
+	    it('should falsify an invalid char', () => {
+	    	expect(LineProcessor.isValidTidalWordChar('*')).toBe(false);
+	    })
     })
 
     describe('isQuotationMark', () => {
-	it('should truthify quotation mark', () => {
-		expect(LineProcessor.isQuotationMark('"')).toBe(true);
-	})
+	    it('should truthify quotation mark', () => {
+	    	expect(LineProcessor.isQuotationMark('"')).toBe(true);
+	    })
 
-  it('should truthify a valid minus', () => {
-    expect(LineProcessor.isValidTidalWordChar('-')).toBe(true);
-	})
-
-  it('should truthify a valid dot', () => {
-		expect(LineProcessor.isValidTidalWordChar('.')).toBe(true);
-	})
-
-	it('should falsify non quotation mark', () => {
-		expect(LineProcessor.isQuotationMark('*')).toBe(false);
-	})
+        it('should truthify a valid minus', () => {
+            expect(LineProcessor.isValidTidalWordChar('-')).toBe(true);
+    	})
+    
+        it('should truthify a valid dot', () => {
+    		expect(LineProcessor.isValidTidalWordChar('.')).toBe(true);
+    	})
+    
+    	it('should falsify non quotation mark', () => {
+    		expect(LineProcessor.isQuotationMark('*')).toBe(false);
+    	})
     })
 
     describe('isQuotationMark', () => {
         it('should find the range for one ControlPattern and one word and execute the callback once', ()  => {
             const results = [];
             LineProcessor.findTidalWordRanges(
-            	`d1 $ s "superpiano" # note 0`,
-            	(result) => results.push(result));
+           	`d1 $ s "superpiano" # note 0`,
+           	(result) => results.push(result));
 
             expect(results.length).toEqual(1);
             expect(results[0]).toEqual({ start: 8, end: 17});
@@ -51,8 +51,8 @@ describe('Line Processor', () => {
         it('should find the range for two ControlPatterns and several words and execute the callback accorgingly', ()  => {
             const results = [];
             LineProcessor.findTidalWordRanges(
-            	`d1 $ s "<superpiano 808>" # note "0"`,
-            	(result) => results.push(result));
+           	`d1 $ s "<superpiano 808>" # note "0"`,
+           	(result) => results.push(result));
 
             expect(results.length).toEqual(3);
             expect(results[0]).toEqual({ start: 9, end: 18});
@@ -64,8 +64,8 @@ describe('Line Processor', () => {
         it('should find the range for one relatively complex ControlPattern and several words and execute the callback accordingly', ()  => {
             const results = [];
             LineProcessor.findTidalWordRanges(
-            	`d1 $ s "superpiano" # note "c'maj'4*<1 2 3>"`,
-            	(result) => results.push(result));
+           	`d1 $ s "superpiano" # note "c'maj'4*<1 2 3>"`,
+           	(result) => results.push(result));
 
             expect(results.length).toEqual(7);
             expect(results[0]).toEqual({ start: 8, end: 17});
@@ -80,30 +80,30 @@ describe('Line Processor', () => {
 
     describe('controlPatternsRegex', () => {
         it ('should match all strings and their quotation marks in a line', () => {
-		const testString = `d1 $ s "<superpiano 808>" # note "0"`;
-		const expected = [`"<superpiano 808>"`, `"0"`];
-
-		expect(testString.match(LineProcessor.controlPatternsRegex())).toEqual(expected);
-	})
+    		const testString = `d1 $ s "<superpiano 808>" # note "0"`;
+    		const expected = [`"<superpiano 808>"`, `"0"`];
+    
+    		expect(testString.match(LineProcessor.controlPatternsRegex())).toEqual(expected);
+    	})
     })
 
     describe('exceptedFunctionPatterns', () => {
         it ('should match numerals function occurance in a line', () => {
-		const testString = `numerals = "0 1 2 3"`;
-		const expected = 'numerals = "0 1 2 3"';
-		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
-	})
+    		const testString = `numerals = "0 1 2 3"`;
+    		const expected = 'numerals = "0 1 2 3"';
+    		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
+    	})
 
         it ('should match p function occurance in a line', () => {
-		const testString = `p "hello" $ s "808"`;
-		const expected = 'p "hello" $ s "808"';
-
-		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
-	})
+    		const testString = `p "hello" $ s "808"`;
+    		const expected = 'p "hello" $ s "808"';
+    
+    		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
+    	})
 
         it ('should not match an allowed control pattern in a line', () => {
-		const testString = `d1 $ s "superpiano"`;
-		expect(testString.match(LineProcessor.exceptedFunctionPatterns())).toBeNull()
-	})
+    		const testString = `d1 $ s "superpiano"`;
+    		expect(testString.match(LineProcessor.exceptedFunctionPatterns())).toBeNull()
+    	})
     })
 })

--- a/spec/line-processor-spec.js
+++ b/spec/line-processor-spec.js
@@ -17,23 +17,31 @@ describe('Line Processor', () => {
 	it('should falsify an invalid char', () => {
 		expect(LineProcessor.isValidTidalWordChar('*')).toBe(false);
 	})
-    }) 
+    })
 
     describe('isQuotationMark', () => {
 	it('should truthify quotation mark', () => {
 		expect(LineProcessor.isQuotationMark('"')).toBe(true);
 	})
 
+  it('should truthify a valid minus', () => {
+    expect(LineProcessor.isValidTidalWordChar('-')).toBe(true);
+	})
+
+  it('should truthify a valid dot', () => {
+		expect(LineProcessor.isValidTidalWordChar('.')).toBe(true);
+	})
+
 	it('should falsify non quotation mark', () => {
 		expect(LineProcessor.isQuotationMark('*')).toBe(false);
 	})
-    }) 
+    })
 
     describe('isQuotationMark', () => {
         it('should find the range for one ControlPattern and one word and execute the callback once', ()  => {
             const results = [];
             LineProcessor.findTidalWordRanges(
-            	`d1 $ s "superpiano" # note 0`, 
+            	`d1 $ s "superpiano" # note 0`,
             	(result) => results.push(result));
 
             expect(results.length).toEqual(1);
@@ -43,7 +51,7 @@ describe('Line Processor', () => {
         it('should find the range for two ControlPatterns and several words and execute the callback accorgingly', ()  => {
             const results = [];
             LineProcessor.findTidalWordRanges(
-            	`d1 $ s "<superpiano 808>" # note "0"`, 
+            	`d1 $ s "<superpiano 808>" # note "0"`,
             	(result) => results.push(result));
 
             expect(results.length).toEqual(3);
@@ -56,7 +64,7 @@ describe('Line Processor', () => {
         it('should find the range for one relatively complex ControlPattern and several words and execute the callback accordingly', ()  => {
             const results = [];
             LineProcessor.findTidalWordRanges(
-            	`d1 $ s "superpiano" # note "c'maj'4*<1 2 3>"`, 
+            	`d1 $ s "superpiano" # note "c'maj'4*<1 2 3>"`,
             	(result) => results.push(result));
 
             expect(results.length).toEqual(7);
@@ -74,7 +82,7 @@ describe('Line Processor', () => {
         it ('should match all strings and their quotation marks in a line', () => {
 		const testString = `d1 $ s "<superpiano 808>" # note "0"`;
 		const expected = [`"<superpiano 808>"`, `"0"`];
-		
+
 		expect(testString.match(LineProcessor.controlPatternsRegex())).toEqual(expected);
 	})
     })
@@ -89,7 +97,7 @@ describe('Line Processor', () => {
         it ('should match p function occurance in a line', () => {
 		const testString = `p "hello" $ s "808"`;
 		const expected = 'p "hello" $ s "808"';
-                
+
 		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
 	})
 

--- a/spec/line-processor-spec.js
+++ b/spec/line-processor-spec.js
@@ -17,12 +17,6 @@ describe('Line Processor', () => {
 	    it('should falsify an invalid char', () => {
 	    	expect(LineProcessor.isValidTidalWordChar('*')).toBe(false);
 	    })
-    })
-
-    describe('isQuotationMark', () => {
-	    it('should truthify quotation mark', () => {
-	    	expect(LineProcessor.isQuotationMark('"')).toBe(true);
-	    })
 
         it('should truthify a valid minus', () => {
             expect(LineProcessor.isValidTidalWordChar('-')).toBe(true);
@@ -31,7 +25,17 @@ describe('Line Processor', () => {
         it('should truthify a valid dot', () => {
     		expect(LineProcessor.isValidTidalWordChar('.')).toBe(true);
     	})
-    
+
+        it('should truthify a valid colon', () => {
+    		expect(LineProcessor.isValidTidalWordChar(':')).toBe(true);
+    	})
+    })
+
+    describe('isQuotationMark', () => {
+	    it('should truthify quotation mark', () => {
+	    	expect(LineProcessor.isQuotationMark('"')).toBe(true);
+	    })
+
     	it('should falsify non quotation mark', () => {
     		expect(LineProcessor.isQuotationMark('*')).toBe(false);
     	})


### PR DESCRIPTION
This will fix the following issues: 
- https://github.com/tidalcycles/pulsar-tidalcycles/issues/221
- https://github.com/tidalcycles/pulsar-tidalcycles/issues/220

General speaking we need to whitelabel chars that are considered as part of a word inside of the mini notation. I added an additional check, that will avoid that the event highlighting crashes because of a wrong tokenization.